### PR TITLE
Artificial rep tree

### DIFF
--- a/R/generate_tree.R
+++ b/R/generate_tree.R
@@ -82,6 +82,12 @@ generate_tree <- function(rf, metric = "weighted splitting variables", train_dat
     stop("Please provide importance values in ranger object")
   }
 
+  if (imp.num.var > 0 & rf$importance.mode == "none" |
+      imp.num.var > 0 & importance.mode == FALSE |
+      rf$importance.mode != "none" & importance.mode == FALSE){
+    stop("Your input was not consistent regarding the use or non-use of importance")
+  }
+
   if (imp.num.var > length(rf$variable.importance)){
     stop("You tried to select more variables by imp.num.var, than splitting variables in the random forest.")
   }

--- a/R/generate_tree.R
+++ b/R/generate_tree.R
@@ -297,4 +297,3 @@ generate_tree <- function(rf, metric = "weighted splitting variables", train_dat
   ## Return reduced ranger object
   return(rf_rep)
 }
-# Test

--- a/R/generate_tree.R
+++ b/R/generate_tree.R
@@ -297,3 +297,4 @@ generate_tree <- function(rf, metric = "weighted splitting variables", train_dat
   ## Return reduced ranger object
   return(rf_rep)
 }
+# Test


### PR DESCRIPTION
Weiterer Fehler wird abgefangen, wenn die Angaben zum Wichtigkeitsmaß nicht zusammen passen, z.B. Wichtigkeit verwendet und importance.mode = FALSE (default) 